### PR TITLE
Update binary sensor device class to Garage door

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,7 +415,7 @@ binary_sensor:
     payload_on: "open"
     payload_off: "closed"
     availability_topic: "GarHAge/availability"
-    device_class: opening
+    device_class: garage_door
     qos: 0
 
   - platform: mqtt
@@ -424,7 +424,7 @@ binary_sensor:
     payload_on: "open"
     payload_off: "closed"
     availability_topic: "GarHAge/availability"
-    device_class: opening
+    device_class: garage_door
     qos: 0  
 ```
 


### PR DESCRIPTION
Small change to make HA see the binary sensor as a garage door as opposed to a generic opening.